### PR TITLE
Fixed #018788: isset is missing if ezjscore server func loaded from file_get_contents()

### DIFF
--- a/classes/ezjscajaxcontent.php
+++ b/classes/ezjscajaxcontent.php
@@ -66,6 +66,8 @@ class ezjscAjaxContent
                                                                                   'xml' => 'xml',
                                                                                   'text' => 'text' ) )
     {
+        $acceptList = array();
+
         if ( isset($_POST['http_accept']) )
             $acceptList = explode( ',', $_POST['http_accept'] );
         else if ( isset($_POST['HTTP_ACCEPT']) )
@@ -74,7 +76,7 @@ class ezjscAjaxContent
             $acceptList = explode( ',', $_GET['http_accept'] );
         else if ( isset($_GET['HTTP_ACCEPT']) )
             $acceptList = explode( ',', $_GET['HTTP_ACCEPT'] );
-        else
+        else if ( isset($_SERVER['HTTP_ACCEPT']) )
             $acceptList = explode( ',', $_SERVER['HTTP_ACCEPT'] );
 
         foreach( $acceptList as $accept )


### PR DESCRIPTION
Fixed #018788: isset is missing if ezjscore server func loaded from file_get_contents() (that doesn't set HTTP_ACCEPT)
