### PR TITLE
setting default packLevel (the less agressive, the most secure)

### DIFF
--- a/classes/ezjsccssoptimizer.php
+++ b/classes/ezjsccssoptimizer.php
@@ -37,7 +37,7 @@ class ezjscCssOptimizer
      * @param int $packLevel Level of packing, values: 2-3
      * @return string
      */
-    public static function optimize( $css, $packLevel )
+    public static function optimize( $css, $packLevel = 2 )
     {
         // Normalize line feeds
         $css = str_replace( array( "\r\n", "\r" ), "\n", $css );

--- a/classes/ezjscjavascriptoptimizer.php
+++ b/classes/ezjscjavascriptoptimizer.php
@@ -38,7 +38,7 @@ class ezjscJavascriptOptimizer
      * @param int $packLevel Level of packing, values: 2-3
      * @return string
      */
-    public static function optimize( $script, $packLevel )
+    public static function optimize( $script, $packLevel = 2 )
     {
         if ( $packLevel > 2 )
         {


### PR DESCRIPTION
several remarks that shows this commit might be interesting:

1/ it's easier for a developer to use that function (only 1 arg instead 2 mandatory args)
2/ packLevel may disappear in the future (as now it's possible to use whatever css/js optimizer we want), so ezjscore should avoid to force developer to set it
3/ possible to use HTML minifiers and give those optimizers as callback, for minifying inline css and js, that way, the HTML minifier will call the callback and give the inline css or js as first arg (for now, eZ yells because the second arg is missing)

What do you think about this André?
