### PR TITLE
upgrade css/js optimizer to ezpEvent logic

### DIFF
--- a/classes/ezjsccssoptimizer.php
+++ b/classes/ezjsccssoptimizer.php
@@ -34,7 +34,7 @@ class ezjscCssOptimizer
      * 'compress' css code by removing whitespace
      *
      * @param string $css Concated Css string
-     * @param int $packLevel Level of packing, values: 2-3
+     * @param int $packLevel Level of packing, values: 1-3
      * @return string
      */
     public static function optimize( $css, $packLevel = 2 )

--- a/classes/ezjsccssoptimizer.php
+++ b/classes/ezjsccssoptimizer.php
@@ -39,6 +39,11 @@ class ezjscCssOptimizer
      */
     public static function optimize( $css, $packLevel = 2 )
     {
+        if ($packLevel < 2)
+        {
+            return $css;
+        }
+
         // Normalize line feeds
         $css = str_replace( array( "\r\n", "\r" ), "\n", $css );
 

--- a/classes/ezjscjavascriptoptimizer.php
+++ b/classes/ezjscjavascriptoptimizer.php
@@ -39,6 +39,11 @@ class ezjscJavascriptOptimizer
      */
     public static function optimize( $script, $packLevel = 2 )
     {
+        if ($packLevel < 2)
+        {
+            return $script;
+        }
+
         // Normalize line feeds
         $script = str_replace( array( "\r\n", "\r" ), "\n", $script );
 

--- a/classes/ezjscjavascriptoptimizer.php
+++ b/classes/ezjscjavascriptoptimizer.php
@@ -34,7 +34,7 @@ class ezjscJavascriptOptimizer
      * 'compress' javascript code by removing whitespace
      *
      * @param string $script Concated JavaScript string
-     * @param int $packLevel Level of packing, values: 2-3
+     * @param int $packLevel Level of packing, values: 1-3
      * @return string
      */
     public static function optimize( $script, $packLevel = 2 )

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,7 +458,7 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
-        $content = ezpEvent::getInstance()->filter( $isCSS ? 'response/outputcss' : 'response/outputjs', $content, $data['pack_level'] );
+        $content = ezpEvent::getInstance()->filter( $isCSS ? 'response/output/css' : 'response/output/javascript', $content, $data['pack_level'] );
 
         // Save cache file and return path
         $clusterFileHandler->fileStoreContents( $data['cache_path'], $content, 'ezjscore', $isCSS ? 'text/css' : 'text/javascript' );

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,7 +458,7 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
-        $content = ezpEvent::getInstance()->filter( $isCSS ? 'response/output/css' : 'response/output/javascript', $content, $data['pack_level'] );
+        $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'response/output/css' : 'response/output/javascript' ), $content, $data['pack_level'] );
 
         // Save cache file and return path
         $clusterFileHandler->fileStoreContents( $data['cache_path'], $content, 'ezjscore', $isCSS ? 'text/css' : 'text/javascript' );

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,6 +458,17 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
+
+        // CssOptimizer and JavascriptOptimizer are deprecated as of 4.7...
+        if ( $data['pack_level'] > 1 )
+        {
+            foreach( $ezjscINI->variable( 'eZJSCore', $isCSS ? 'CssOptimizer' : 'JavaScriptOptimizer' ) as $optimizer )
+            {
+                $content = call_user_func( array( $optimizer, 'optimize' ), $content, $data['pack_level'] );
+            }
+        }
+
+        // ... to the benefit of Event logic
         $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'optimize/css' : 'optimize/javascript' ),
                                                     $content,
                                                     $data['pack_level'] );

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,7 +458,9 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
-        $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'response/output/css' : 'response/output/javascript' ), $content, $data['pack_level'] );
+        $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'response/output/css' : 'response/output/javascript' ),
+                                                    $content,
+                                                    $data['pack_level'] );
 
         // Save cache file and return path
         $clusterFileHandler->fileStoreContents( $data['cache_path'], $content, 'ezjscore', $isCSS ? 'text/css' : 'text/javascript' );

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,7 +458,7 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
-        $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'response/output/css' : 'response/output/javascript' ),
+        $content = ezpEvent::getInstance()->filter( ( $isCSS ? 'optimize/css' : 'optimize/javascript' ),
                                                     $content,
                                                     $data['pack_level'] );
 

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -458,13 +458,7 @@ class ezjscPacker
         }
 
         // Pack all files to save bandwidth
-        if ( $data['pack_level'] > 1 )
-        {
-            foreach( $ezjscINI->variable( 'eZJSCore', $isCSS ? 'CssOptimizer' : 'JavaScriptOptimizer' ) as $optimizer )
-            {
-                $content = call_user_func( array( $optimizer, 'optimize' ), $content, $data['pack_level'] );
-            }
-        }
+        $content = ezpEvent::getInstance()->filter( $isCSS ? 'response/outputcss' : 'response/outputjs', $content, $data['pack_level'] );
 
         // Save cache file and return path
         $clusterFileHandler->fileStoreContents( $data['cache_path'], $content, 'ezjscore', $isCSS ? 'text/css' : 'text/javascript' );

--- a/settings/ezjscore.ini
+++ b/settings/ezjscore.ini
@@ -8,9 +8,11 @@
 # Force packer level by setting integer from 0 to 3 instead of [dis|en]abled
 #Packer=disabled
 
+# Deprecated since 4.7, use site.ini [Event] Listeners[]=optimize/javascript@<callback> instead!
 JavaScriptOptimizer[]
 JavaScriptOptimizer[]=ezjscJavascriptOptimizer
 
+# Deprecated since 4.7, use site.ini [Event] Listeners[]=optimize/css@<callback> instead!
 CssOptimizer[]
 CssOptimizer[]=ezjscCssOptimizer
 

--- a/settings/ezjscore.ini
+++ b/settings/ezjscore.ini
@@ -8,11 +8,11 @@
 # Force packer level by setting integer from 0 to 3 instead of [dis|en]abled
 #Packer=disabled
 
-# Deprecated since 4.7, use site.ini [Event] Listeners[]=optimize/javascript@<callback> instead!
+# Not used anymore since 4.7, use site.ini [Event] Listeners[]=optimize/javascript@<callback> instead!
 JavaScriptOptimizer[]
 JavaScriptOptimizer[]=ezjscJavascriptOptimizer
 
-# Deprecated since 4.7, use site.ini [Event] Listeners[]=optimize/css@<callback> instead!
+# Not used anymore since 4.7, use site.ini [Event] Listeners[]=optimize/css@<callback> instead!
 CssOptimizer[]
 CssOptimizer[]=ezjscCssOptimizer
 

--- a/settings/ezjscore.ini
+++ b/settings/ezjscore.ini
@@ -8,11 +8,11 @@
 # Force packer level by setting integer from 0 to 3 instead of [dis|en]abled
 #Packer=disabled
 
-# Not used anymore since 4.7, use site.ini [Event] Listeners[]=optimize/javascript@<callback> instead!
+# Deprecated as of 4.7, use site.ini [Event] Listeners[]=optimize/javascript@<callback> instead!
 JavaScriptOptimizer[]
 JavaScriptOptimizer[]=ezjscJavascriptOptimizer
 
-# Not used anymore since 4.7, use site.ini [Event] Listeners[]=optimize/css@<callback> instead!
+# Deprecated as of 4.7, use site.ini [Event] Listeners[]=optimize/css@<callback> instead!
 CssOptimizer[]
 CssOptimizer[]=ezjscCssOptimizer
 

--- a/settings/site.ini.append.php
+++ b/settings/site.ini.append.php
@@ -1,8 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
 [Event]
-Listeners[]=optimize/css@ezjscCssOptimizer::optimize
-Listeners[]=optimize/javascript@ezjscJavascriptOptimizer::optimize
+Listeners[ezjscore_css_optimizer]=optimize/css@ezjscCssOptimizer::optimize
+Listeners[ezjscore_javascript_optimizer]=optimize/javascript@ezjscJavascriptOptimizer::optimize
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ezjscore

--- a/settings/site.ini.append.php
+++ b/settings/site.ini.append.php
@@ -1,8 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
 [Event]
-Listeners[css_optimizer]=response/output/css@ezjscCssOptimizer::optimize
-Listeners[javascript_optimizer]=response/output/javascript@ezjscJavascriptOptimizer::optimize
+Listeners[css_optimizer]=optimize/css@ezjscCssOptimizer::optimize
+Listeners[javascript_optimizer]=optimize/javascript@ezjscJavascriptOptimizer::optimize
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ezjscore

--- a/settings/site.ini.append.php
+++ b/settings/site.ini.append.php
@@ -1,8 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
 [Event]
-Listeners[css_optimizer]=optimize/css@ezjscCssOptimizer::optimize
-Listeners[javascript_optimizer]=optimize/javascript@ezjscJavascriptOptimizer::optimize
+Listeners[]=optimize/css@ezjscCssOptimizer::optimize
+Listeners[]=optimize/javascript@ezjscJavascriptOptimizer::optimize
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ezjscore

--- a/settings/site.ini.append.php
+++ b/settings/site.ini.append.php
@@ -1,5 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
+[Event]
+Listeners[]=response/outputcss@ezjscCssOptimizer::optimize
+Listeners[]=response/outputjs@ezjscJavascriptOptimizer::optimize
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ezjscore

--- a/settings/site.ini.append.php
+++ b/settings/site.ini.append.php
@@ -1,8 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
 [Event]
-Listeners[]=response/outputcss@ezjscCssOptimizer::optimize
-Listeners[]=response/outputjs@ezjscJavascriptOptimizer::optimize
+Listeners[css_optimizer]=response/output/css@ezjscCssOptimizer::optimize
+Listeners[javascript_optimizer]=response/output/javascript@ezjscJavascriptOptimizer::optimize
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ezjscore


### PR DESCRIPTION
The Pull is speaking: "Don't merge me, I'm buggy!"...

It's just a pull to start a discussion, because I have 2 problems with current ezp logic

First and foremost, there's an event response/output to trigger some callbacks whenever the html is pushed to the client, thanks to ezpEvent

This feature is really nice, and even so nice that it may be interesting to put those ezpEvent everywhere!

And why not in ezjscore, whenever it wants to push css or js to the client (just like html indeed)?

=> So I would say it would be interesting to create 2 new events: response/outputcss and response/outputjs (or even a more cosmetic response/output/css, response/output/js), just like the current response/output (which could be renamed into response/output/html)

Of course, feel free to tell me if you find first this idea stupid, but even if it is, it's interesting to read below

You can quickly look at the pull to understand how it can easily be done

BUT it's buggy, in fact it's currently impossible to call a filter with more than one argument, which is the value that the filter may alter

1/ Here I find this logic to be too restrictive, it would be nice to call a filter with a value, and maybe another param, for example the context (in this pull, the second param needed would be the packLevel), and in the long run as many params as possible
=> so why not add some logic of func_get_args() in the ezpEvent::filter() function ? the ezpEvent::notify() already supports an array as param where it's possible to push many arguments, but it doesn't alter the value, which is what I need here

2/ and second, imagine now this pull is correct (it would if ezpEvent::filter() could support many args). I have still a problem...
Ok, the code would work, it could minify css and js
But imagine a developer wants then to create another extension that bundles custom minifiers for css and js, and he doesn't want the default js/css minifier of ezjscore to be triggered at all

=> how can he/she deletes those lines? :

`````` Listeners[]=response/outputcss@ezjscCssOptimizer::optimize
Listeners[]=response/outputjs@ezjscJavascriptOptimizer::optimize```

and put his/her classes ?
Of course, it's impossible to do Listeners[]= to empty (because it would empty all callbacks for all filters)
The developer would only want to empty the callbacks triggered by response/outputcss, in order to put his/her callbacks

If the syntax was: 
```Listeners[response/outputcss]=ezjscCssOptimizer::optimize```

Then the developer could empty Listeners[response/outputcss] and afterwards put his/her classes. But of course this syntax is too limitative as it's impossible to put more than one callback to an event. It's just to explain the problem I have to tackle with

=> You see a simple solution ?

(the first I can see if for the developer to have his/her extension loaded first, and detach asap all other callbacks for the response/outputcss for example, but not totally sure it would work, because this detach may occur too late, after the foreach of ezpEvent::filter())
Whatever, this trick is more complex then just performing the common Setting[]= to empty the array and feed it from the start

Any idea on this logic for settings Listeners in site.ini ?
``````
