### PR TITLE
Fixed #018317: ezjscore no more drops abusively js code when minifying on specific case

### DIFF
--- a/classes/ezjscjavascriptoptimizer.php
+++ b/classes/ezjscjavascriptoptimizer.php
@@ -42,12 +42,12 @@ class ezjscJavascriptOptimizer
         // Normalize line feeds
         $script = str_replace( array( "\r\n", "\r" ), "\n", $script );
 
+        // Remove whitespace from start & end of line + singelline comment + multiple linefeeds
+        $script = preg_replace( array( '/\n\s+/', '/\s+\n/', '#\n\s*//.*#', '/\n+/' ), "\n", $script );
+
         // Remove multiline comments
         $script = preg_replace( '!(?:\n|\s|^)/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $script );
         $script = preg_replace( '!(?:;)/\*[^*]*\*+([^/][^*]*\*+)*/!', ';', $script );
-
-        // Remove whitespace from start & end of line + singelline comment + multiple linefeeds
-        $script = preg_replace( array( '/\n\s+/', '/\s+\n/', '#\n\s*//.*#', '/\n+/' ), "\n", $script );
 
         return $script;
     }


### PR DESCRIPTION
ezjscore is smart enough to _not_ consider a start of multiline comment when it's wrapped between quotes.
For example "var foo = '/*'" is not a start of a multiline comment, it's just a string...

BUT ezjscore thinks that the string "//   /*" is a start of a multiline comment. However no, it's just a singleline comment...

I've encountered this problem when using the standard ezjscore minify function on JSLint.js

The fix is, in fact, quite easy, once the real reason has been understood...
=> ezjscore must first clean the singleline comments _before_ the multiline comments (that way, the strings "//  /*" will be dropped first, which will ease the regex for detecting the multiline comments)

If I plug in André's head, I guess he wanted to clean the singleline comments, and multiple linefeeds _after_ the multiline comments, because the clean of multiline comments may add some extra \n\n, so better to clean afterwards all \n+ after multiline comments, but then this specific bug can occur...

So order should be inversed, hence this commit

And maybe we can add after the multiline comments removal, another regex to delete the \n+ that may appears after the multiline comments removal

Tell me if it's really useful...
