### PR TITLE
Added CSS optimizer to inline small image files as a Data URL.

### DIFF
--- a/classes/ezjsccssinlineimageoptimizer.php
+++ b/classes/ezjsccssinlineimageoptimizer.php
@@ -1,0 +1,51 @@
+<?php
+//
+// Definition of ezjscCssInlineImageOptimizer class
+//
+// Created on: 2012-01-19 19:00
+// Author: johan.beronius@athega.se
+//
+
+class ezjscCssInlineImageOptimizer
+{
+    /**
+     * Inline small images as Data URL in the CSS to minimize number of HTTP requests.
+     *
+     * @param string $css Concated Css string
+     * @param int $packLevel Level of packing, values: 2-3
+     * @return string
+     */
+    public static function optimize( $css, $packLevel = 2 )
+    {
+        $maxBytes = 2048;
+        $ezjscINI    = eZINI::instance( 'ezjscore.ini' );
+        if ( $ezjscINI->hasVariable( 'ezjscCssInlineImageOptimizer', 'InlineImageMaxBytes' ) )
+        {
+            $maxBytes = (int) $ezjscINI->variable( 'ezjscCssInlineImageOptimizer', 'InlineImageMaxBytes' );
+        }
+
+        if ( $packLevel > 2 && $maxBytes > 0 && preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&#]+)[\'|\"]?\s*\)/ix", $css, $urlMatches ) )
+        {
+           $urlMatches = array_unique( $urlMatches[1] );
+           foreach ( $urlMatches as $match )
+           {
+               if ( $match[0] === '/' && preg_match("/\.(gif|png|jpe?g)$/i", $match, $imageType))
+               {
+                   $imagePath = '.' . $match;
+                   $imageSize = filesize($imagePath);
+                   if ($imageSize !== false && $imageSize > 0 && $imageSize < $maxBytes)
+                   {
+                        if ($imageType[1] == 'jpg')
+                            $imageType[1] = 'jpeg';
+
+                        $imageContents = file_get_contents($imagePath);
+                        $dataURL = 'data:image/' . $imageType[1] . ';base64,' . base64_encode($imageContents);
+                        $css = str_replace( $match, $dataURL, $css );
+                   }
+               }
+           }
+        }
+        return $css;
+    }
+}
+?>

--- a/settings/ezjscore.ini
+++ b/settings/ezjscore.ini
@@ -13,6 +13,8 @@ JavaScriptOptimizer[]=ezjscJavascriptOptimizer
 
 CssOptimizer[]
 CssOptimizer[]=ezjscCssOptimizer
+#CssOptimizer[]=ezjscCssInlineImageOptimizer
+
 
 ## CDN Script settings (jQuery/ Yui integration)
 # The following settings in this block are specific to ezjscore's
@@ -125,3 +127,10 @@ Class=ezjscServerFunctionsAjaxUploader
 AjaxUploadHandler[]
 AjaxUploadHandler[ezobjectrelationlist]=ezpRelationListAjaxUploader
 AjaxUploadHandler[ezobjectrelation]=ezpRelationAjaxUploader
+
+
+
+#[ezjscCssInlineImageOptimizer]
+## Maximum filesize for images to be inlined as a Data URL in the CSS.
+## If not set the default value of 2048 will be used.
+#InlineImageMaxBytes=2048


### PR DESCRIPTION
Not sure if this is the best place for this feature.
I originally developed this feature as a patch for 'ezjscpacker.php' in our installation of eZ Publish 4.5.
When I later adapted it for the latest version of ezjscore I discovered that optimizers are now configurable and can be loaded from any class. I guess that way they can be placed in any extension.
If you don't thinks this fit here, please give me a tip on the best way to share this code.
