### PR TITLE
Fixed #19233: CSS packer badly rewrites images url when an extension CSS uses an image from eZ Publish

### DIFF
--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -498,7 +498,12 @@ class ezjscPacker
                if ( $match[0] !== '/' and strpos( $match, 'http:' ) === false )
                {
                    $cssPathSlice = $relativeCount === 0 ? $cssPathArray : array_slice( $cssPathArray  , 0, $cssPathCount - $relativeCount  );
-                   $newMatchPath = self::getWwwDir() . implode( '/', $cssPathSlice ) . '/' . str_replace( '../', '', $match );
+                   $newMatchPath = self::getWwwDir();
+                   if ( !empty( $cssPathSlice ) )
+                   {
+                       $newMatchPath .= implode( '/', $cssPathSlice ) . '/';
+                   }
+                   $newMatchPath .= str_replace( '../', '', $match );
                    $fileContent = str_replace( $match, $newMatchPath, $fileContent );
                }
            }


### PR DESCRIPTION
Bug discovered while working on https://github.com/ezsystems/ezautosave/pull/2
