### PR TITLE
Content returned from a server function that requests not to be cached.

### DIFF
--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -268,6 +268,8 @@ class ezjscPacker
             $data['cache_name'] = $data['index_dir'];
         }
 
+        $originalFileArray = $fileArray;
+
         while ( !empty( $fileArray ) )
         {
             $file = array_shift( $fileArray );
@@ -381,9 +383,15 @@ class ezjscPacker
             // if packing is disabled, return the valid paths / content we have generated
             return array_merge( $data['http'], $data['www'] );
         }
+        else if ( empty($data['locale']) && !empty($data['http']) )
+        {
+            self::$log[] = $data;
+            // return if there are only external scripts and no local files to cache
+            return $data['http'];
+        }
         else if ( !$data['locale'] )
         {
-            eZDebug::writeWarning( "Could not find any files: " . var_export( $fileArray, true ), __METHOD__ );
+            eZDebug::writeWarning( "Could not find any files: " . var_export( $originalFileArray, true ), __METHOD__ );
             return array();
         }
         else if ( !isset( $data['locale'][1] ) && $data['locale'][0] && !$data['locale'][0] instanceof ezjscServerRouter )
@@ -599,7 +607,9 @@ class ezjscPacker
             if ( !isset( $data['http'][$i+1] ) && $data['cache_path'] !== '' )
                 break;
 
-            if ( $stats !== '' )
+            if ( !$file )
+                continue;
+            elseif ( $stats !== '' )
                 $stats .= '<br />';
 
             $stats .= "<span class='debuginfo' title='Served directly from external source(not part of cache file)'>{$file}</span>";

--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -299,9 +299,10 @@ class ezjscPacker
                    $data['www'][] = $server->call( $fileArray );
                 }
                 // Always generate functions with file_time=-1 (they modify $fileArray )
+                // or they return content that should not be part of the cache file
                 else if ( $fileTime === -1 )
                 {
-                    $data['locale'][] = $server->call( $fileArray );
+                    $data['http'][] = $server->call( $fileArray );
                 }
                 else
                 {


### PR DESCRIPTION
I'd like to use this pull request to discuss the code on line 304 of ezjscpacker.

I understand that some js server functions can request not to be cached by returning -1 from getCacheTime. They do this because they add other files instead and therefore they do not return any content other than the empty string.
But if they were to return any content, since it's added to $data['locale'] array, it's treated as the filename of a local file to be included in the generated cache file. If it's not a valid filename that will cause a PHP warning "file_get_contents: failed to open stream: No such file or directory"

If any returned content is added to the $data['http'] array instead, it's then treated as an URL to an external javascript resource or as a fragment of javascript code to be included inline in its own script-tag. It is possible to add external URLs to the file array today, but it is not possible to insert any javascript code beside the cache file and external URLs.

I've come around this problem since I need to prevent some javascript fragments from being included in the cache file. Almost every page on our site requires a few fragments of unique javascript code and that is causing ezjscpacker to generate a unique cache file for every page on the entire site.
