### PR TITLE
Prevents private functions call from outside a ezjscServerFunctions class

### DIFF
--- a/classes/ezjscserverrouter.php
+++ b/classes/ezjscserverrouter.php
@@ -197,7 +197,7 @@ class ezjscServerRouter
         }
         else
         {
-            return is_callable( "{$className}::{$functionName}" );
+            return is_callable( array( $className, $functionName ) );
         }
     }
 

--- a/classes/ezjscserverrouter.php
+++ b/classes/ezjscserverrouter.php
@@ -197,7 +197,7 @@ class ezjscServerRouter
         }
         else
         {
-            return method_exists( $className, $functionName );
+            return is_callable( "{$className}::{$functionName}" );
         }
     }
 


### PR DESCRIPTION
Considering that we have a class AServerFunctions extending ezjscServerFunctions

``` php

<?php

/**
* A class to call server side functions using ajax through eZJscore
*
*/
class AServerFunctions extends ezjscServerFunctions
{
    public static function callableFunctionA( $args )
    {
        return self::notACallableFunction();
    }

    public static function callableFunctionB( $args )
    {
        return self::notACallableFunction();
    }

    private static function notACallableFunction( )
    {
        return "something";
    }
}

```

Functions `callableFunctionA` and `callableFunctionB` are public static & callable using ezjscore/call/aserver::callableFunctionA

but `notACallableFunction` should not be callable by ezjscore/call since it's a private function. 

ezjscServerRouter::staticHasFunction() should not only check if the function exists, this commit aims to fix this
