### PR TITLE
Fixed #19487: Packer template operators do not execute optimizer when called with only one file

### DIFF
--- a/classes/ezjscpacker.php
+++ b/classes/ezjscpacker.php
@@ -385,12 +385,6 @@ class ezjscPacker
             eZDebug::writeWarning( "Could not find any files: " . var_export( $fileArray, true ), __METHOD__ );
             return array();
         }
-        else if ( !isset( $data['locale'][1] ) && $data['locale'][0] && !$data['locale'][0] instanceof ezjscServerRouter )
-        {
-            self::$log[] = $data;
-            // return if there is only one file in array to save us from caching it
-            return array_merge( $data['http'], $data['www'] );
-        }
 
         // See if cahe file exists and if it has expired (only if time is not part of name)
         if ( $ezjscINI->variable( 'Packer', 'AppendLastModifiedTime' ) === 'enabled' )


### PR DESCRIPTION
Actually, it seems like it's done like this on purpose [1] However, IMHO even with one file, executing the optimizer(s) might be useful but obviously one might have another opinion :)

[1] https://github.com/ezsystems/ezjscore/commit/e99dc53ea3bb01a1a857af00ec15f50878fa5626
