### PR TITLE
ezscriptfiles_load operator

### DIFF
--- a/autoloads/ezjscpackertemplatefunctions.php
+++ b/autoloads/ezjscpackertemplatefunctions.php
@@ -47,6 +47,7 @@
  *                                   [, int $pack_level=3]]]]])
  *
  * ezscriptfiles( array|string $scripts[, int $pack_level=2[, bool $ignore_loaded=false]] )
+ * ezscriptfiles_load( array|string $scripts[, int $pack_level=2] )
  * ezcssfiles( array|string $css_files[, int $pack_level=3[, bool $ignore_loaded=false]] )
  *
  * These are alternatives to ezscript and ezcss that return array of files to be included
@@ -65,7 +66,7 @@
  * You can also use css / js generators to generate content dynamically.
  * This is better explained in ezjscore.ini[Packer_<function>]
  *
- * Brief (ezscript|ezcss)_require + (ezscript|ezcss)_load:
+ * Brief (ezscript|ezcss)_require + (ezscript|ezscriptfiles|ezcss)_load:
  * Lets you do on demand loading of javscript and css files instead of loading
  * them on every page using JavaScriptList & CSSFileList witch tends to also
  * load files no matter what design you use.
@@ -76,7 +77,7 @@
  * by (ezscript|ezcss)_load. If already loaded, then executed right away just like
  * calling (ezscript|ezcss) operators.
  *
- * (ezscript|ezcss)_load : Packs the files you (optionally) pass to it + the files marked
+ * (ezscript|ezscriptfiles|ezcss)_load : Packs the files you (optionally) pass to it + the files marked
  * to be loaded by (ezscript|ezcss)_require.
  */
 

--- a/autoloads/ezjscpackertemplatefunctions.php
+++ b/autoloads/ezjscpackertemplatefunctions.php
@@ -90,7 +90,7 @@ class ezjscPackerTemplateFunctions
 
     function operatorList()
     {
-        return array( 'ezscript', 'ezscript_require', 'ezscript_load', 'ezscriptfiles', 'ezcss', 'ezcss_require', 'ezcss_load', 'ezcssfiles'  );
+        return array( 'ezscript', 'ezscript_require', 'ezscript_load', 'ezscriptfiles', 'ezscriptfiles_load', 'ezcss', 'ezcss_require', 'ezcss_load', 'ezcssfiles'  );
     }
 
     function namedParameterPerOperator()
@@ -159,6 +159,9 @@ class ezjscPackerTemplateFunctions
             $def['ezscript_require'] = $def['ezscript'];
             $def['ezscript_load'] = $def['ezscript'];
             $def['ezscript_load']['script_array']['required'] = false;
+            $def['ezscriptfiles_load'] = $def['ezscriptfiles'];
+            $def['ezscriptfiles_load']['script_array']['required'] = false;
+            unset($def['ezscriptfiles_load']['ignore_loaded']);
 
             $def['ezcss_require'] = $def['ezcss'];
             $def['ezcss_load'] = $def['ezcss'];
@@ -233,6 +236,21 @@ class ezjscPackerTemplateFunctions
                     $ret = ezjscPacker::buildJavascriptFiles( $diff, $namedParameters['pack_level'] );
                 }
             } break;
+            case 'ezscriptfiles_load':
+            	{
+            		if ( !isset( self::$loaded['js_files'] ) )
+            		{
+            			$depend = self::setPersistentArray( 'js_files', self::flattenArray( $namedParameters['script_array'] ), $tpl, false, true );
+            			$ret = ezjscPacker::buildJavascriptFiles( $depend, $namedParameters['pack_level'] );
+            			self::$loaded['js_files'] = true;
+            			break;
+            		}// let 'ezscript' handle loaded calls
+            		elseif ( $operatorName === 'ezscript_load' )
+            		{
+            			$namedParameters['script_array'] = self::setPersistentArray( 'js_files', self::flattenArray( $namedParameters['script_array'] ), $tpl, true, true, true );
+            		}
+            		
+            	} break;
             case 'ezcss_load':
             {
                 if ( !isset( self::$loaded['css_files'] ) )

--- a/doc/FAQ
+++ b/doc/FAQ
@@ -2,5 +2,5 @@ FAQ for ezjscore 1.x
 ====================
 
 Q: I used the ezcss_require()/ezscript_require() template operator in my code but no css/js files are included in my html page
-A: You need to put the ezcss_load()/ezscript_load() template operator in your pagelayout template.
+A: You need to put the ezcss_load()/ezscript_load()/ezscriptfiles_load() template operator in your pagelayout template.
    For an example, see the templates provided in the extension in design/ezwebin/templates/* that does this automatically for ezwebin (+ezflow).


### PR DESCRIPTION
New template operator which combines the power of ezscriptfiles with ezscript_load.

While ezscriptfiles can load (or optionally ignore) files requested with ezscript_require, you cannot separate these from "site-wide" js files set in design.ini.

ezscriptfiles_load() allows you to load only page-specific files and output as an array of file paths.
