### PR TITLE
Fixed wrong links after eZPublish Legacy repo rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Warning
 
 This repository is not used anymore, the eZJSCore code has been moved in the
-[eZ Publish repository](https://github.com/ezsystems/ezpublish) in [the
-extension folder](https://github.com/ezsystems/ezpublish/tree/master/extension/ezjscore).
+[eZ Publish repository](https://github.com/ezsystems/ezpublish-legacy) in [the
+extension folder](https://github.com/ezsystems/ezpublish-legacy/tree/master/extension/ezjscore).
 
 If you are about to create a pull request, please do it against the eZ Publish
 repository.


### PR DESCRIPTION
Those links were broken after the rename of the repos. 
Let me know if do you need an issue in the tracker for this or this pr could be enough. 
